### PR TITLE
Revise browser support

### DIFF
--- a/docs/introduction/appendix.md
+++ b/docs/introduction/appendix.md
@@ -11,13 +11,10 @@ order: 5
 Spectre uses [Autoprefixer](https://github.com/postcss/autoprefixer) to make most styles compatible with earlier browsers and [Normalize.css](https://necolas.github.io/normalize.css/) for CSS resets. Spectre is designed for modern browsers. For best compatibility, these browsers are recommended:
 
 * Chrome LAST 4
-* Microsoft Edge LAST 4
+* Edge LAST 4
+* Firefox LAST 4
 * Firefox Extended Support Release
 * Safari LAST 4
-* Opera LAST 4
-* Internet Explorer 10+
-
-Spectre supports Internet Explorer 10+, but some HTML5 and CSS3 features are not perfectly supported by Internet Explorer.
 
 ## Changes
 


### PR DESCRIPTION
I was looking at this section to understand what changes I would be able to make in Spectre to modernize it. Because it includes Internet Explorer, I am basically unable to make any improvements.

As the note on line 11 mentions, Spectre is designed for modern browsers, and I think we should stay true to that and remove support for Internet Explorer, since it is completely dead and practically has no user base anymore.

I also made some slight adjustments to the other ones. I removed Opera, since it is no longer a custom browser but simply one of 100 forks of Chromium.

I changed "Microsoft Edge" to "Edge" because it is more in line with the other browser names.

I added "Firefox LAST 4" because it confused me that only ESR was mentioned, I think this makes it more clear what exactly is supported.