### PR TITLE
Remove EdgeHTML references

### DIFF
--- a/docs/components/accordions.md
+++ b/docs/components/accordions.md
@@ -102,7 +102,7 @@ Accordions are used to toggle sections of content.
 
 ```
 
-Alternatively, you can use `details` and `summary` instead of `input` radio or checkbox trick. Add the `open` attribute to `details` to expand it. Microsoft Edge support is [under consideration](https://developer.microsoft.com/en-us/microsoft-edge/platform/status/detailssummary/).
+Alternatively, you can use `details` and `summary` instead of `input` radio or checkbox trick. Add the `open` attribute to `details` to expand it.
 
 ```html
 <!-- details and summary Accordions example -->

--- a/docs/elements/media.md
+++ b/docs/elements/media.md
@@ -22,7 +22,7 @@ Add the `img-responsive` class to `<img>` elements. The images will scale with t
 
 ```
 
-Add the `img-fit-contain` or `img-fit-cover` class to `<img>` or `<video>` elements. The media will crop itself to fit inside the element (and you don't need another container). This feature can replace the classic background image trick. Microsoft Edge support [is shipped](https://developer.microsoft.com/en-us/microsoft-edge/platform/status/objectfitandobjectposition/) with Build Number 16299+.
+Add the `img-fit-contain` or `img-fit-cover` class to `<img>` or `<video>` elements. The media will crop itself to fit inside the element (and you don't need another container). This feature can replace the classic background image trick.
 
  
 <div class="vp-raw docs-demo columns">


### PR DESCRIPTION
These notes are for the old and unsupported non-chromium Edge. There is no reason to keep them around.